### PR TITLE
Add BBC Changelog

### DIFF
--- a/BBC-CHANGELOG.md
+++ b/BBC-CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This changelog aims to document all the high-level changes added by the BBC on top of upstream IMSC.
+
+For more detailed changes, please use the commit history.
+
+## Changes
+
+- Handle TTML1 1st Edition CR ttaf namespace declarations
+

--- a/BBC-CHANGELOG.md
+++ b/BBC-CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-This changelog aims to document all the high-level changes added by the BBC on top of upstream IMSC.
+This changelog aims to document all the high-level changes added by the BBC on top of upstream [sandflow/imscJS](https://github.com/sandflow/imscJS) library.
 
 For more detailed changes, please use the commit history.
 


### PR DESCRIPTION
This PR introduces a `BBC-CHANGELOG.md` file which aims to capture high-level changes we make on top of the upstream imscJS repo. 

It currently only captures the changes I am aware of. There are probably more. 

This is to help pulling in future updates to upstream into our fork, as well as understand how we've diverged.