### PR TITLE
Cleanup the character spans

### DIFF
--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -574,7 +574,7 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
 
             }
 
-            mergeSpans(proc_e);
+            mergeSpans(linelist);
         }
 
 
@@ -621,22 +621,22 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
         }
     }
 
-    function mergeSpans(node) {
-        for (var c = 0; c < node.children.length; c++) {
-            var child = node.children[c];
+    function mergeSpans(lineList) {
+        for (var i = 0; i < lineList.length; i++) {
+            var line = lineList[i];
 
-            mergeSpans(child);
-        }
+            for (var j = 1; j < line.elements.length;) {
+                var previous = line.elements[j-1];
+                var span = line.elements[j];
 
-        for (var i = 1; i < node.children.length;) {
-            var previous = node.children[i-1];
-            var span = node.children[i];
+                if (spanMerge(previous.node, span.node)) {
+                    //removed from DOM by spanMerge(), remove from the list too.
+                    line.elements.splice(j, 1);
+                    continue;
+                } else {
+                    j++;
+                }
 
-            if (previous.children.length === 0 && span.children.length === 0 && spanMerge(previous, span)) {
-                //deleted by spanMerge()
-                continue;
-            } else {
-                i++;
             }
         }
     }
@@ -655,6 +655,8 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
             second.parentElement.removeChild(second);
             return true;
         }
+
+        return false;
     }
 
     function applyLinePadding(lineList, lp, context) {

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -618,8 +618,6 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
                 }
 
             }
-
-            /* TODO: clean-up the spans ? */
         }
     }
 
@@ -647,9 +645,10 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
         if (first.tagName === "SPAN" && second.tagName === "SPAN" && first._isd_element === second._isd_element) {
             first.textContent += second.textContent;
 
-            for (var s of second.style) {
-                if (s.indexOf("border") >= 0 || s.indexOf("padding") >= 0) {
-                    first.style[s] = second.style[s];
+            for (var i = 0; i < second.style.length; i++) {
+                var styleName = second.style[i];
+                if (styleName.indexOf("border") >= 0 || styleName.indexOf("padding") >= 0) {
+                    first.style[styleName] = second.style[styleName];
                 }
             }
 

--- a/src/main/js/html.js
+++ b/src/main/js/html.js
@@ -473,6 +473,8 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
 
                         cbuf = '';
 
+                        //For the sake of merging these back together, record what isd element generated it.
+                        span._isd_element = isd_element;
                     }
 
                 }
@@ -572,6 +574,7 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
 
             }
 
+            mergeSpans(proc_e);
         }
 
 
@@ -617,7 +620,41 @@ var backgroundColorAdjustSuffix = "BackgroundColorAdjust";
             }
 
             /* TODO: clean-up the spans ? */
+        }
+    }
 
+    function mergeSpans(node) {
+        for (var c = 0; c < node.children.length; c++) {
+            var child = node.children[c];
+
+            mergeSpans(child);
+        }
+
+        for (var i = 1; i < node.children.length;) {
+            var previous = node.children[i-1];
+            var span = node.children[i];
+
+            if (previous.children.length === 0 && span.children.length === 0 && spanMerge(previous, span)) {
+                //deleted by spanMerge()
+                continue;
+            } else {
+                i++;
+            }
+        }
+    }
+
+    function spanMerge(first, second) {
+        if (first.tagName === "SPAN" && second.tagName === "SPAN" && first._isd_element === second._isd_element) {
+            first.textContent += second.textContent;
+
+            for (var s of second.style) {
+                if (s.indexOf("border") >= 0 || s.indexOf("padding") >= 0) {
+                    first.style[s] = second.style[s];
+                }
+            }
+
+            second.parentElement.removeChild(second);
+            return true;
         }
     }
 


### PR DESCRIPTION
Having a span on each character is causing various rendering bugs and making screenreaders read each letter separately.

For each char span generated, this records the ISD element it came from, and then later, loops over leaf nodes that are spans and merges adjacent ones that came from the same ISD element.