### PR TITLE
Render subtitles that have a bad region ID

### DIFF
--- a/src/main/js/doc.js
+++ b/src/main/js/doc.js
@@ -1105,7 +1105,21 @@
             if (doc.head.layout.regions[region]) {
                 this.regionID = region;
             } else {
+                var defaultRegion;
+                for (var r in doc.head.layout.regions) {
+                    if (doc.head.layout.regions.hasOwnProperty(r) && doc.head.layout.regions[r].isDefaultRegion) {
+                        defaultRegion = doc.head.layout.regions[r];
+                        break;
+                    }
+                }
+                if (!defaultRegion) {
+                    defaultRegion = Region.prototype.createDefaultRegion(doc, errorHandler);
+                    doc.head.layout.regions[defaultRegion.id] = defaultRegion;
+                }
+
                 reportError(errorHandler, "Cannot find specified region: " + region);
+
+                //Leave regionID unset to use this default region.
             }
         }
     };
@@ -1330,6 +1344,7 @@
 
         this.lang = doc.xmllang;
 
+        r.isDefaultRegion = true;
         return r;
     };
 

--- a/src/main/js/doc.js
+++ b/src/main/js/doc.js
@@ -1100,7 +1100,14 @@
     }
 
     LayoutElement.prototype.initFromNode = function (doc, parent, node, errorHandler) {
-        this.regionID = elementGetRegionID(node);
+        var region = elementGetRegionID(node);
+        if (region) {
+            if (doc.head.layout.regions[region]) {
+                this.regionID = region;
+            } else {
+                reportError(errorHandler, "Cannot find specified region: " + region);
+            }
+        }
     };
 
     function StyledElement(styleAttrs) {


### PR DESCRIPTION
When a layoutelement refers to a region that doesn't exist, do not use the region ID and report it as an error. It will be rendered in the default region instead.